### PR TITLE
Added support for DGS-1210-48

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ D-Link
 * dlink DES-3526
 * dlink DES-3552
 * dlink DGS-3312SR
+* dlink DGS-1210-48
 
 SNR
 ---

--- a/dlink.exp
+++ b/dlink.exp
@@ -108,6 +108,16 @@ expect {
         set success "Done."
     }
 
+    "DGS-1210-48" {
+        set username "UserName:"
+        set password "PassWord:"
+        set upload "upload cfg_toTFTP $tftp $config"
+        set upload2 "upload cfg_toTFTP $tftp $config"
+        set logout "logout"
+        set greeting "#"
+        set success "Done."
+    }
+
 
 }
 


### PR DESCRIPTION
I find this script useful, so I've decided to use it.
This small add provides support for TFTP backup for the popular DGS-1210-48